### PR TITLE
Fixed personality not injected into the prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ This project is mainly created as a pet project to understand the inner workings
 - Python (tested in 3.12)
 - [Text generation WebUI](https://github.com/oobabooga/text-generation-webui/) in API mode. If you want to use a different (cloud) service, update the contents of the `getCompletion` function.
 
+### Suggested models
+- [MaziyarPanahi/Meta-Llama-3-8B-Instruct-GGUF](https://huggingface.co/MaziyarPanahi/Meta-Llama-3-8B-Instruct-GGUF): This works pretty decent on an old PC with a RTX 970. Not the fastest, but it gets the job done.
+
 ## Setup
 ```powershell
 python -m venv venv\

--- a/main.py
+++ b/main.py
@@ -41,10 +41,13 @@ class Assistant:
             "Content-Type": "application/json"
         }
         self.history.append({"role": "user", "content": messageText})
-        
+
+        messages = []
+        messages.append({"role": "system", "content": Personality})
+
         data = {
-            "mode": "chat",
-            "messages": self.history[HistorySize:]
+            "mode": "instruct",
+            "messages": messages + self.history[HistorySize:]
         }
 
         response = requests.post(LlmApiAddress, headers=headers, json=data, verify=False)


### PR DESCRIPTION
Made sure the personality prompt is always injected into the completions request as a `system` prompt. Also tested around with a few different models. Found a GGUF version of Llama 3 (8B) currently honors the personality the most.